### PR TITLE
Update for Beat Saber 1.17.0

### DIFF
--- a/SongPlayHistory/SPHUI.cs
+++ b/SongPlayHistory/SPHUI.cs
@@ -136,7 +136,7 @@ namespace SongPlayHistoryContinued
             {
                 List<Record> truncated = records.Take(10).ToList();
 
-                var notesCount = beatmap.beatmapData.cuttableNotesType;
+                var notesCount = beatmap.beatmapData.cuttableNotesCount;
                 var maxScore = ScoreModel.MaxRawScoreForNumberOfNotes(notesCount);
                 var builder = new StringBuilder(200);
 
@@ -244,7 +244,7 @@ namespace SongPlayHistoryContinued
                 var maxCombo = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "MaxCombo");
                 var highscore = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "Highscore");
                 var maxRank = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "MaxRank");
-                var notesCount = beatmap.beatmapData.cuttableNotesType;
+                var notesCount = beatmap.beatmapData.cuttableNotesCount;
                 var maxScore = ScoreModel.MaxRawScoreForNumberOfNotes(notesCount);
                 var estimatedAcc = stats.highScore / (float)maxScore * 100f;
                 SetValue(maxCombo, stats.validScore ? $"{stats.maxCombo}" : "-");

--- a/SongPlayHistory/SongPlayHistoryContinued.csproj
+++ b/SongPlayHistory/SongPlayHistoryContinued.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>SongPlayHistoryContinued</AssemblyName>
-    <AssemblyVersion>1.6.0</AssemblyVersion>
+    <AssemblyVersion>1.6.1</AssemblyVersion>
     <LangVersion>8.0</LangVersion>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <BeatSaberDir>$(ProjectDir)References</BeatSaberDir>

--- a/SongPlayHistory/manifest.json
+++ b/SongPlayHistory/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "author": "peperoro",
   "description": "A score tracker with simple in-game UI.",
-  "gameVersion": "1.16.4",
+  "gameVersion": "1.17.0",
   "id": "SongPlayHistoryContinued",
   "name": "SongPlayHistoryContinued",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "dependsOn": {
     "BSIPA": "^4.1.6",
     "BeatSaberMarkupLanguage": "^1.5.3",


### PR DESCRIPTION
- Changed `cuttableNotesType` to `cuttableNotesCount`
- Version bump to 1.6.1