### PR TITLE
Update for Beat Saber 1.21.0

### DIFF
--- a/SongPlayHistory.UnitTest/SongPlayHistory.UnitTest.csproj
+++ b/SongPlayHistory.UnitTest/SongPlayHistory.UnitTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <BeatSaberDir>$(ProjectDir)..\SongPlayHistory\References</BeatSaberDir>
+    <BeatSaberDir>$(BeatSaberDir)</BeatSaberDir>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/SongPlayHistory/BeatSaberUI.cs
+++ b/SongPlayHistory/BeatSaberUI.cs
@@ -1,4 +1,4 @@
-﻿using BS_Utils.Utilities;
+﻿using IPA.Utilities;
 using HMUI;
 using System.Linq;
 using UnityEngine;
@@ -33,23 +33,23 @@ namespace SongPlayHistoryContinued
                 {
                     _flowCoordinator = Resources.FindObjectsOfTypeAll<SoloFreePlayFlowCoordinator>().LastOrDefault();
 
-                    ResultsViewController = _flowCoordinator?.GetPrivateField<ResultsViewController>("_resultsViewController");
-                    var leaderboardViewController = _flowCoordinator?.GetPrivateField<PlatformLeaderboardViewController>("_platformLeaderboardViewController");
-                    LeaderboardLevelStatsView = leaderboardViewController?.GetPrivateField<LevelStatsView>("_levelStatsView");
+                    ResultsViewController = _flowCoordinator?.GetField<ResultsViewController, LevelSelectionFlowCoordinator>("_resultsViewController");
+                    var leaderboardViewController = _flowCoordinator?.GetField<PlatformLeaderboardViewController, LevelSelectionFlowCoordinator>("_platformLeaderboardViewController");
+                    LeaderboardLevelStatsView = leaderboardViewController?.GetField<LevelStatsView, PlatformLeaderboardViewController>("_levelStatsView");
                 }
                 else
                 {
                     var parent = Resources.FindObjectsOfTypeAll<GameServerLobbyFlowCoordinator>().LastOrDefault();
-                    _flowCoordinator = parent?.GetPrivateField<MultiplayerLevelSelectionFlowCoordinator>("_multiplayerLevelSelectionFlowCoordinator");
+                    _flowCoordinator = parent?.GetField<MultiplayerLevelSelectionFlowCoordinator, GameServerLobbyFlowCoordinator>("_multiplayerLevelSelectionFlowCoordinator");
                 }
 
-                var levelSelectionNavController = _flowCoordinator?.GetPrivateField<LevelSelectionNavigationController>("levelSelectionNavigationController");
-                var levelCollectionNavController = levelSelectionNavController?.GetPrivateField<LevelCollectionNavigationController>("_levelCollectionNavigationController");
-                LevelDetailViewController = levelCollectionNavController?.GetPrivateField<StandardLevelDetailViewController>("_levelDetailViewController");
-                var levelDetailView = LevelDetailViewController?.GetPrivateField<StandardLevelDetailView>("_standardLevelDetailView");
-                LevelParamsPanel = levelDetailView?.GetPrivateField<LevelParamsPanel>("_levelParamsPanel");
-                var levelCollectionViewController = levelCollectionNavController?.GetPrivateField<LevelCollectionViewController>("_levelCollectionViewController");
-                LevelCollectionTableView = levelCollectionViewController?.GetPrivateField<LevelCollectionTableView>("_levelCollectionTableView");
+                var levelSelectionNavController = _flowCoordinator?.GetField<LevelSelectionNavigationController, LevelSelectionFlowCoordinator>("levelSelectionNavigationController");
+                var levelCollectionNavController = levelSelectionNavController?.GetField<LevelCollectionNavigationController, LevelSelectionNavigationController>("_levelCollectionNavigationController");
+                LevelDetailViewController = levelCollectionNavController?.GetField<StandardLevelDetailViewController, LevelCollectionNavigationController>("_levelDetailViewController");
+                var levelDetailView = LevelDetailViewController?.GetField<StandardLevelDetailView, StandardLevelDetailViewController>("_standardLevelDetailView");
+                LevelParamsPanel = levelDetailView?.GetField<LevelParamsPanel, StandardLevelDetailView>("_levelParamsPanel");
+                var levelCollectionViewController = levelCollectionNavController?.GetField<LevelCollectionViewController, LevelCollectionNavigationController>("_levelCollectionViewController");
+                LevelCollectionTableView = levelCollectionViewController?.GetField<LevelCollectionTableView, LevelCollectionViewController>("_levelCollectionTableView");
             }
         }
 
@@ -57,7 +57,7 @@ namespace SongPlayHistoryContinued
         {
             if (IsValid)
             {
-                LevelCollectionTableView?.GetPrivateField<TableView>("_tableView")?.RefreshCellsContent();
+                LevelCollectionTableView?.GetField<TableView, LevelCollectionTableView>("_tableView")?.RefreshCellsContent();
             }
         }
     }

--- a/SongPlayHistory/BeatSaberUI.cs
+++ b/SongPlayHistory/BeatSaberUI.cs
@@ -32,9 +32,9 @@ namespace SongPlayHistoryContinued
                 if (value)
                 {
                     _flowCoordinator = Resources.FindObjectsOfTypeAll<SoloFreePlayFlowCoordinator>().LastOrDefault();
-
-                    ResultsViewController = _flowCoordinator?.GetField<ResultsViewController, LevelSelectionFlowCoordinator>("_resultsViewController");
-                    var leaderboardViewController = _flowCoordinator?.GetField<PlatformLeaderboardViewController, LevelSelectionFlowCoordinator>("_platformLeaderboardViewController");
+                    
+                    ResultsViewController = (_flowCoordinator as SoloFreePlayFlowCoordinator)?.GetField<ResultsViewController, SoloFreePlayFlowCoordinator>("_resultsViewController");
+                    var leaderboardViewController = (_flowCoordinator as SoloFreePlayFlowCoordinator)?.GetField<PlatformLeaderboardViewController, SoloFreePlayFlowCoordinator>("_platformLeaderboardViewController");
                     LeaderboardLevelStatsView = leaderboardViewController?.GetField<LevelStatsView, PlatformLeaderboardViewController>("_levelStatsView");
                 }
                 else

--- a/SongPlayHistory/Plugin.cs
+++ b/SongPlayHistory/Plugin.cs
@@ -41,7 +41,6 @@ namespace SongPlayHistoryContinued
         {
             BSEvents.gameSceneLoaded += OnGameSceneLoaded;
             BSEvents.LevelFinished += OnLevelFinished;
-            // BS_Utils.Plugin.MultiLevelDidFinishEvent += OnMultilevelFinished;
 
             // Init after the menu scene is loaded.
             BSEvents.lateMenuSceneLoadedFresh += (o) =>
@@ -58,7 +57,6 @@ namespace SongPlayHistoryContinued
         {
             BSEvents.gameSceneLoaded -= OnGameSceneLoaded;
             BSEvents.LevelFinished -= OnLevelFinished;
-            // BS_Utils.Plugin.MultiLevelDidFinishEvent -= OnMultilevelFinished;
 
             SPHModel.BackupRecords();
         }
@@ -95,11 +93,6 @@ namespace SongPlayHistoryContinued
             }
             
         }
-
-        // private void OnMultilevelFinished(MultiplayerLevelScenesTransitionSetupDataSO scene, LevelCompletionResults result, IReadOnlyList<MultiplayerPlayerResultsData> _)
-        // {
-        //     SaveRecord(scene?.difficultyBeatmap, result, true);
-        // }
 
         private void SaveRecord(IDifficultyBeatmap beatmap, LevelCompletionResults result, bool isMultiplayer)
         {

--- a/SongPlayHistory/Plugin.cs
+++ b/SongPlayHistory/Plugin.cs
@@ -123,7 +123,7 @@ namespace SongPlayHistoryContinued
                 else if (!enabled && Harmony.HasAnyPatches(HarmonyId))
                 {
                     Log.Info("Removing Harmony patches...");
-                    _harmony.UnpatchAll(HarmonyId);
+                    _harmony.UnpatchSelf();
 
                     SetDataFromLevelAsync.OnUnpatch();
                 }

--- a/SongPlayHistory/SPHController.cs
+++ b/SongPlayHistory/SPHController.cs
@@ -139,14 +139,15 @@ namespace SongPlayHistoryContinued
             Plugin.Log?.Info("Refreshing data...");
 
             var beatmap = BeatSaberUI.LevelDetailViewController?.selectedDifficultyBeatmap;
+            var playerData = SPHModel.GetPlayerData();
             if (beatmap == null)
             {
                 return;
             }
             try
             {
-                _pluginUI.SetRecords(beatmap, SPHModel.GetRecords(beatmap));
-                _pluginUI.SetStats(beatmap, SPHModel.GetPlayerStats(beatmap));
+                _pluginUI.SetRecords(beatmap, playerData, SPHModel.GetRecords(beatmap));
+                _pluginUI.SetStats(beatmap, SPHModel.GetPlayerStats(beatmap), playerData);
             }
             catch (Exception ex) // Any UnityException
             {

--- a/SongPlayHistory/SPHModel.cs
+++ b/SongPlayHistory/SPHModel.cs
@@ -80,8 +80,8 @@ namespace SongPlayHistoryContinued
                 return;
             }
 
-            // Cancelled?
-            if (result.levelEndStateType == LevelCompletionResults.LevelEndStateType.None)
+            // Cancelled.
+            if (result.levelEndStateType == LevelCompletionResults.LevelEndStateType.Incomplete)
             {
                 return;
             }
@@ -119,7 +119,7 @@ namespace SongPlayHistoryContinued
             {
                 Date = DateTimeOffset.Now.ToUnixTimeMilliseconds(),
                 ModifiedScore = result.modifiedScore,
-                RawScore = result.rawScore,
+                RawScore = result.multipliedScore,
                 LastNote = cleared ? -1 : result.goodCutsCount + result.badCutsCount + result.missedCount,
                 Param = (int)param
             };
@@ -153,6 +153,16 @@ namespace SongPlayHistoryContinued
                 Plugin.Log?.Warn($"{nameof(PlayerLevelStatsData)} not found for {beatmap.level.levelID} - {beatmap.difficulty}.");
             }
             return stats;
+        }
+        
+        public static PlayerData GetPlayerData()
+        {
+            if (!BeatSaberUI.IsValid)
+            {
+                return null;
+            }
+            var playerDataModel = BeatSaberUI.LevelDetailViewController.GetField<PlayerDataModel, StandardLevelDetailViewController>("_playerDataModel");
+            return playerDataModel.playerData;
         }
 
         public static bool ScanVoteData()

--- a/SongPlayHistory/SPHModel.cs
+++ b/SongPlayHistory/SPHModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using IPA.Utilities;
 
 namespace SongPlayHistoryContinued
 {
@@ -144,7 +145,7 @@ namespace SongPlayHistoryContinued
             {
                 return null;
             }
-            var playerDataModel = BeatSaberUI.LevelDetailViewController.GetPrivateField<PlayerDataModel>("_playerDataModel");
+            var playerDataModel = BeatSaberUI.LevelDetailViewController.GetField<PlayerDataModel, StandardLevelDetailViewController>("_playerDataModel");
             var statsList = playerDataModel.playerData.levelsStatsData;
             var stats = statsList?.FirstOrDefault(x => x.levelID == beatmap.level.levelID && x.difficulty == beatmap.difficulty);
             if (stats == null)

--- a/SongPlayHistory/SPHUI.cs
+++ b/SongPlayHistory/SPHUI.cs
@@ -86,7 +86,7 @@ namespace SongPlayHistoryContinued
                     hoverHint.text = "";
                 }
                 var hoverHintController = Resources.FindObjectsOfTypeAll<HoverHintController>().First();
-                hoverHint.SetPrivateField("_hoverHintController", hoverHintController);
+                hoverHint.SetField("_hoverHintController", hoverHintController);
                 return hoverHint;
             }
         }

--- a/SongPlayHistory/SPHUI.cs
+++ b/SongPlayHistory/SPHUI.cs
@@ -125,9 +125,9 @@ namespace SongPlayHistoryContinued
             }
         }
 
-        public void SetRecords(IDifficultyBeatmap beatmap, List<Record> records)
+        public async void SetRecords(IDifficultyBeatmap beatmap, PlayerData playerData, List<Record> records)
         {
-            if (HoverHint == null || beatmap == null)
+            if (HoverHint == null || beatmap == null || playerData == null)
             {
                 return;
             }
@@ -136,8 +136,8 @@ namespace SongPlayHistoryContinued
             {
                 List<Record> truncated = records.Take(10).ToList();
 
-                var notesCount = beatmap.beatmapData.cuttableNotesCount;
-                var maxScore = ScoreModel.MaxRawScoreForNumberOfNotes(notesCount);
+                var beatmapData = await beatmap.GetBeatmapDataAsync(beatmap.GetEnvironmentInfo(), playerData.playerSpecificSettings);
+                var maxScore = ScoreModel.ComputeMaxMultipliedScoreForBeatmap(beatmapData);
                 var builder = new StringBuilder(200);
 
                 static string ConcatParam(Param param)
@@ -222,7 +222,7 @@ namespace SongPlayHistoryContinued
             }
         }
 
-        public void SetStats(IDifficultyBeatmap beatmap, PlayerLevelStatsData stats)
+        public async void SetStats(IDifficultyBeatmap beatmap, PlayerLevelStatsData stats, PlayerData playerData)
         {
             if (beatmap == null || stats == null)
             {
@@ -244,8 +244,8 @@ namespace SongPlayHistoryContinued
                 var maxCombo = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "MaxCombo");
                 var highscore = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "Highscore");
                 var maxRank = LevelStatsView.GetComponentsInChildren<RectTransform>().First(x => x.name == "MaxRank");
-                var notesCount = beatmap.beatmapData.cuttableNotesCount;
-                var maxScore = ScoreModel.MaxRawScoreForNumberOfNotes(notesCount);
+                var beatmapData = await beatmap.GetBeatmapDataAsync(beatmap.GetEnvironmentInfo(), playerData.playerSpecificSettings);
+                var maxScore = ScoreModel.ComputeMaxMultipliedScoreForBeatmap(beatmapData);
                 var estimatedAcc = stats.highScore / (float)maxScore * 100f;
                 SetValue(maxCombo, stats.validScore ? $"{stats.maxCombo}" : "-");
                 SetValue(highscore, stats.validScore ? $"{stats.highScore} ({estimatedAcc:0.00}%)" : "-");

--- a/SongPlayHistory/SPHUI.cs
+++ b/SongPlayHistory/SPHUI.cs
@@ -195,13 +195,14 @@ namespace SongPlayHistoryContinued
                     // var denom = PluginConfig.Instance.AverageAccuracy && r.LastNote > 0 ? adjMaxScore : maxScore;
                     // var accuracy = r.RawScore / (float)denom * 100f;
                     
+                    var levelFinished = r.LastNote < 0;
+                    var accuracy = r.RawScore / (float) maxScore * 100f;
+                    
                     /*
-                     * One possible solution is to store the max possible score when a level finish,
-                     * Then we just use previous saved max score to calculate acc
+                     * One possible solution is to get the max possible score when a level finish as mentioned above,
+                     * And store it in SongPlayData.json along all other things.
+                     * Then we can just use this saved max score to calculate acc
                      */
-
-                    var levelFinished = r.LastNote > 0;
-                    var accuracy = r.RawScore / (float) maxScore;
 
                     var param = ConcatParam((Param)r.Param);
                     if (param.Length == 0 && r.RawScore != r.ModifiedScore)

--- a/SongPlayHistory/SongPlayHistoryContinued.csproj
+++ b/SongPlayHistory/SongPlayHistoryContinued.csproj
@@ -130,8 +130,9 @@
     <ErrorOnMismatchedVersions Condition="'$(Configuration)' == 'Release'">True</ErrorOnMismatchedVersions>
   </PropertyGroup>
   <Target Name="CopyToPlugins" AfterTargets="Build" Condition="'$(NCrunch)' != '1'">
-    <Message Text="Copying $(OutputAssemblyName).dll to IPA\Pending\Plugins folder" Importance="high" />
+    <Message Text="Copying $(OutputAssemblyName).dll and $(OutputAssemblyName).pdb to IPA\Pending\Plugins folder" Importance="high" />
     <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(BeatSaberDir)\IPA\Pending\Plugins\$(AssemblyName).dll" />
+    <Copy SourceFiles="$(OutputAssemblyName).pdb" DestinationFiles="$(BeatSaberDir)\IPA\Pending\Plugins\$(AssemblyName).pdb" />
   </Target>
   <Target Name="GetProjectInfo" AfterTargets="BeforeBuild" Condition="'$(BSMTTaskAssembly)' != ''">
     <GetManifestInfo ManifestPath="manifest.json">

--- a/SongPlayHistory/manifest.json
+++ b/SongPlayHistory/manifest.json
@@ -1,14 +1,14 @@
 ﻿{
   "author": "peperoro",
   "description": "A score tracker with simple in-game UI.",
-  "gameVersion": "1.17.0",
+  "gameVersion": "1.21.0",
   "id": "SongPlayHistoryContinued",
   "name": "SongPlayHistoryContinued",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "dependsOn": {
-    "BSIPA": "^4.1.6",
-    "BeatSaberMarkupLanguage": "^1.5.3",
-    "BS Utils": "^1.10.0"
+    "BSIPA": "^4.2.2",
+    "BeatSaberMarkupLanguage": "^1.6.3",
+    "BS Utils": "^1.12.0"
   },
   "links": {
     "project-home": "https://github.com/Shadnix-was-taken/BeatSaber-SongPlayHistoryContinued"


### PR DESCRIPTION
A lot of things changed.

1. Some obsoleted events in BS_Utils are removed, so changed to use the new BSEvents in BS_Utils.
2. Reflection Utils in BS_Utils were obsoleted and removed, so changed to use BSIPA's reflection utils.
3. Updated scoring stuff access to 1.21.0 game version. Because of the new note type, there is no easy way of calculating max possible score from the number of notes. A possible solution I can think of is storing the max score into the song play data when a new record is made. 
4. Because of 3, acc of failed/unfinished play record will not be displayed anymore.
