### PR TITLE
The Unmerged Changes from #6

### DIFF
--- a/SongPlayHistory/HarmonyPatches.cs
+++ b/SongPlayHistory/HarmonyPatches.cs
@@ -8,12 +8,11 @@ using static UnityEngine.Object;
 
 namespace SongPlayHistoryContinued
 {
-    [HarmonyPatch(typeof(LevelListTableCell))]
-    [HarmonyPatch("SetDataFromLevelAsync", new Type[] { typeof(IPreviewBeatmapLevel), typeof(bool) })]
+    [HarmonyPatch(typeof(LevelListTableCell), nameof(LevelListTableCell.SetDataFromLevelAsync))]
     internal class SetDataFromLevelAsync
     {
-        private static Sprite _thumbsUp;
-        private static Sprite _thumbsDown;
+        private static Sprite? _thumbsUp;
+        private static Sprite? _thumbsDown;
 
         public static bool Prepare()
         {
@@ -23,7 +22,7 @@ namespace SongPlayHistoryContinued
             return SPHModel.ScanVoteData();
         }
 
-        [HarmonyAfter(new string[] { "com.kyle1413.BeatSaber.SongCore" })]
+        [HarmonyAfter("com.kyle1413.BeatSaber.SongCore")]
         public static void Postfix(LevelListTableCell __instance, IPreviewBeatmapLevel level, bool isFavorite,
             Image ____favoritesBadgeImage,
             TextMeshProUGUI ____songBpmText)

--- a/SongPlayHistory/Plugin.cs
+++ b/SongPlayHistory/Plugin.cs
@@ -22,6 +22,7 @@ namespace SongPlayHistoryContinued
 
         private readonly Harmony _harmony;
         private bool _isPractice;
+        private bool _isReplay;
 
         [Init]
         public Plugin(Logger logger, Config config)
@@ -65,10 +66,17 @@ namespace SongPlayHistoryContinued
         {
             var practiceSettings = BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData?.practiceSettings;
             _isPractice = practiceSettings != null;
+            _isReplay = Utils.IsInReplay();
         }
 
         private void OnLevelFinished(object scene, LevelFinishedEventArgs eventArgs)
         {
+            if (_isReplay)
+            {
+                Log.Info("It was a replay, ignored.");
+                return;
+            }
+            
             if (eventArgs.LevelType != LevelType.Multiplayer && eventArgs.LevelType != LevelType.SoloParty)
             {
                 return;
@@ -86,6 +94,7 @@ namespace SongPlayHistoryContinued
                 // solo
                 if (_isPractice || Gamemode.IsPartyActive)
                 {
+                    Log.Info("It was in practice or party mode, ignored.");
                     return;
                 }
                 var beatmap = ((StandardLevelScenesTransitionSetupDataSO)scene)?.difficultyBeatmap;
@@ -94,7 +103,7 @@ namespace SongPlayHistoryContinued
             
         }
 
-        private void SaveRecord(IDifficultyBeatmap beatmap, LevelCompletionResults result, bool isMultiplayer)
+        private void SaveRecord(IDifficultyBeatmap? beatmap, LevelCompletionResults? result, bool isMultiplayer)
         {
             if (result?.multipliedScore > 0)
             {

--- a/SongPlayHistory/SPHModel.cs
+++ b/SongPlayHistory/SPHModel.cs
@@ -73,7 +73,7 @@ namespace SongPlayHistoryContinued
             return new List<Record>();
         }
 
-        public static void SaveRecord(IDifficultyBeatmap beatmap, LevelCompletionResults result, bool submissionDisabled, bool isMultiplayer)
+        public static void SaveRecord(IDifficultyBeatmap? beatmap, LevelCompletionResults? result, bool submissionDisabled, bool isMultiplayer)
         {
             if (beatmap == null || result == null)
             {

--- a/SongPlayHistory/ScoreTracker.cs
+++ b/SongPlayHistory/ScoreTracker.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Zenject;
+
+namespace SongPlayHistoryContinued
+{
+    public class ScoreTrackerInstaller : Installer<ScoreTrackerInstaller>
+    {
+        public override void InstallBindings()
+        {
+            Plugin.Log.Warn("Binding ScoreTracker");
+            Container.BindInterfacesTo<ScoreTracker>().AsSingle().NonLazy();
+        }
+    }
+    
+    public class ScoreTracker : IInitializable, IDisposable
+    {
+        internal static int? MaxRawScore = null;
+        
+        [InjectOptional]
+        private IScoreController? _scoreController = null;
+
+        public void Initialize()
+        {
+            MaxRawScore = null;
+            if (_scoreController != null)
+            {
+                _scoreController.scoringForNoteFinishedEvent += OnScoreChanged;
+            } 
+            else 
+            {
+                Plugin.Log.Warn("scoreController is null!");
+            }
+        }
+
+        private void OnScoreChanged(ScoringElement _)
+        {
+            MaxRawScore = _scoreController?.immediateMaxPossibleMultipliedScore;
+        }
+
+        public void Dispose()
+        {
+            if (_scoreController != null)
+            {
+                Plugin.Log.Info($"Max possible score w/o modifiers: {MaxRawScore}");
+                _scoreController.scoringForNoteFinishedEvent -= OnScoreChanged;
+            }
+        }
+    }
+}

--- a/SongPlayHistory/ScoreUtils.cs
+++ b/SongPlayHistory/ScoreUtils.cs
@@ -1,0 +1,25 @@
+﻿namespace SongPlayHistoryContinued
+{
+    internal static class ScoreUtils
+    {
+        // *wink* *wink*
+        internal static int CalculateV2MaxScore(int noteCount)
+        {
+            int effectiveNoteCount = 0;
+            int multiplier;
+            for (multiplier = 1; multiplier < 8; multiplier *= 2)
+            {
+                if (noteCount < multiplier * 2)
+                {
+                    effectiveNoteCount += multiplier * noteCount;
+                    noteCount = 0;
+                    break;
+                }
+                effectiveNoteCount += multiplier * multiplier * 2 + multiplier;
+                noteCount -= multiplier * 2;
+            }
+            effectiveNoteCount += noteCount * multiplier;
+            return effectiveNoteCount * 115;
+        }
+    }
+}

--- a/SongPlayHistory/SongPlayHistoryContinued.csproj
+++ b/SongPlayHistory/SongPlayHistoryContinued.csproj
@@ -2,12 +2,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <AssemblyName>SongPlayHistoryContinued</AssemblyName>
     <AssemblyVersion>1.6.1</AssemblyVersion>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <BeatSaberDir>$(ProjectDir)References</BeatSaberDir>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Optimize>False</Optimize>
@@ -24,6 +25,12 @@
     <Reference Include="0Harmony">
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="BeatLeader">
+      <HintPath>$(BeatSaberDir)\Plugins\BeatLeader.dll</HintPath>
+    </Reference>
+    <Reference Include="Hive.Versioning">
+      <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>

--- a/SongPlayHistory/SongPlayHistoryContinued.csproj
+++ b/SongPlayHistory/SongPlayHistoryContinued.csproj
@@ -72,6 +72,9 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Polyglot.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="SiraUtil">
+      <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
@@ -107,6 +110,12 @@
     <Reference Include="VRUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\VRUI.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Zenject">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+    </Reference>
+    <Reference Include="Zenject-usage">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SongPlayHistory/Utils.cs
+++ b/SongPlayHistory/Utils.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using System.Reflection;
+using BeatLeader.Replayer;
+using HarmonyLib;
+using IPA.Loader;
+using Hive.Versioning;
+
+namespace SongPlayHistoryContinued
+{
+    internal static class Utils
+    {
+        #region replay check (copied from HRCounter, MIT LICENSE: https://github.com/qe201020335/HRCounter/blob/master/LICENSE)
+        private const string BEATLEADER_MOD_ID = "BeatLeader";
+
+        private static bool? _beatleaderHasReplay = null;
+
+        internal static bool BeatLeaderHasReplay
+        {
+            get
+            {
+                var blVersion = FindEnabledPluginMetadata(BEATLEADER_MOD_ID)?.HVersion;
+                _beatleaderHasReplay ??= blVersion != null && blVersion >= new Version(0, 5, 0);
+                return _beatleaderHasReplay.Value;
+            }
+        }
+
+        // copied from Camera2
+        private static readonly MethodBase? ScoreSaber_playbackEnabled =
+            AccessTools.Method("ScoreSaber.Core.ReplaySystem.HarmonyPatches.PatchHandleHMDUnmounted:Prefix");
+        
+        internal static bool IsInReplay()
+        {
+            // copied from Camera2
+            var ssReplay = ScoreSaber_playbackEnabled != null && (bool) ScoreSaber_playbackEnabled.Invoke(null, null) == false;
+
+            var blReplay = BeatLeaderHasReplay && ReplayerLauncher.IsStartedAsReplay;
+            
+            return ssReplay || blReplay;
+        }
+        #endregion replay
+        
+        internal static bool IsModEnabled(string id)
+        {
+            return FindEnabledPluginMetadata(id) != null;
+        }
+        
+        internal static PluginMetadata? FindEnabledPluginMetadata(string id)
+        {
+            return PluginManager.EnabledPlugins.FirstOrDefault(x => x.Id == id);
+        }
+
+    }
+}

--- a/SongPlayHistory/Utils.cs
+++ b/SongPlayHistory/Utils.cs
@@ -9,45 +9,25 @@ namespace SongPlayHistoryContinued
 {
     internal static class Utils
     {
-        #region replay check (copied from HRCounter, MIT LICENSE: https://github.com/qe201020335/HRCounter/blob/master/LICENSE)
-        private const string BEATLEADER_MOD_ID = "BeatLeader";
-
-        private static bool? _beatleaderHasReplay = null;
-
-        internal static bool BeatLeaderHasReplay
-        {
-            get
-            {
-                var blVersion = FindEnabledPluginMetadata(BEATLEADER_MOD_ID)?.HVersion;
-                _beatleaderHasReplay ??= blVersion != null && blVersion >= new Version(0, 5, 0);
-                return _beatleaderHasReplay.Value;
-            }
-        }
-
+        #region replay check (copied from HRCounter) 
+        // MIT LICENSE: https://github.com/qe201020335/HRCounter/blob/master/LICENSE)
         // copied from Camera2
-        private static readonly MethodBase? ScoreSaber_playbackEnabled =
+         private static readonly MethodBase? ScoreSaber_playbackEnabled =
             AccessTools.Method("ScoreSaber.Core.ReplaySystem.HarmonyPatches.PatchHandleHMDUnmounted:Prefix");
+
+        private static readonly MethodBase? GetBeatLeaderIsStartedAsReplay =
+            AccessTools.Property(AccessTools.TypeByName("BeatLeader.Replayer.ReplayerLauncher"), "IsStartedAsReplay")?.GetGetMethod(false);
+
         
         internal static bool IsInReplay()
         {
             // copied from Camera2
             var ssReplay = ScoreSaber_playbackEnabled != null && (bool) ScoreSaber_playbackEnabled.Invoke(null, null) == false;
 
-            var blReplay = BeatLeaderHasReplay && ReplayerLauncher.IsStartedAsReplay;
+            var blReplay = GetBeatLeaderIsStartedAsReplay != null && (bool) GetBeatLeaderIsStartedAsReplay.Invoke(null, null);
             
             return ssReplay || blReplay;
         }
-        #endregion replay
-        
-        internal static bool IsModEnabled(string id)
-        {
-            return FindEnabledPluginMetadata(id) != null;
-        }
-        
-        internal static PluginMetadata? FindEnabledPluginMetadata(string id)
-        {
-            return PluginManager.EnabledPlugins.FirstOrDefault(x => x.Id == id);
-        }
-
+        #endregion
     }
 }

--- a/SongPlayHistory/manifest.json
+++ b/SongPlayHistory/manifest.json
@@ -1,14 +1,15 @@
 ﻿{
   "author": "peperoro",
   "description": "A score tracker with simple in-game UI.",
-  "gameVersion": "1.21.0",
+  "gameVersion": "1.27.0",
   "id": "SongPlayHistoryContinued",
   "name": "SongPlayHistoryContinued",
   "version": "1.6.2",
   "dependsOn": {
     "BSIPA": "^4.2.2",
     "BeatSaberMarkupLanguage": "^1.6.3",
-    "BS Utils": "^1.12.0"
+    "BS Utils": "^1.12.0",
+    "SiraUtil": "^3.0.0"
   },
   "links": {
     "project-home": "https://github.com/Shadnix-was-taken/BeatSaber-SongPlayHistoryContinued"

--- a/SongPlayHistory/manifest.json
+++ b/SongPlayHistory/manifest.json
@@ -4,7 +4,7 @@
   "gameVersion": "1.27.0",
   "id": "SongPlayHistoryContinued",
   "name": "SongPlayHistoryContinued",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "dependsOn": {
     "BSIPA": "^4.2.2",
     "BeatSaberMarkupLanguage": "^1.6.3",

--- a/SongPlayHistory/manifest.json
+++ b/SongPlayHistory/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "author": "peperoro",
   "description": "A score tracker with simple in-game UI.",
-  "gameVersion": "1.27.0",
+  "gameVersion": "1.28.0",
   "id": "SongPlayHistoryContinued",
   "name": "SongPlayHistoryContinued",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "dependsOn": {
     "BSIPA": "^4.2.2",
     "BeatSaberMarkupLanguage": "^1.6.3",


### PR DESCRIPTION
This is a re-opened pr because I created a new branch to not spam this pr with all my future commits.

Changes:
- Identify whether the result is from ScoreSaver or BeatLeader replay. Ignore if it is.
- Add the failed acc back. Added a new field in the `Record` model for max raw score.
- Support for Game version 1.28.0

Copied From #6 :

The max raw score is actually not accessible at all outside of the game play context and it only exists in the `ScoreController`. Well, I guess I have to track and pass the value myself then. SiraUtil and Zenject to the rescue!

For all the existing records, if the max scores can be calculated with the old method, i.e. there is no slider or burst in the map, I simply calculate the max score with the note count `Record.LastNote`.

The OldschoolBeatSaber mod will break this. Simply installing the mod will cause the SPH hover hint ui not to load. There won't be any exceptions, just like SPH is not installed but new records will still be saved. This seems to be because OldschoolBeatSaber provides a re-implementation of some old-school elements of HMUI and SPH's reflection may be finding the wrong types.